### PR TITLE
Fix broken links on web accessibility page

### DIFF
--- a/_posts/2015-10-01-tips-for-getting-started-with-web-accessibility.md
+++ b/_posts/2015-10-01-tips-for-getting-started-with-web-accessibility.md
@@ -6,11 +6,11 @@ date: 2015-10-01
 
 <ul>
 
-  <li><a href="{{ "/tips/" | relative_url }}designing.html">Tips on Designing for Web Accessibility</a> - Tips for user interface and visual design</li>
+  <li><a href="{{ "/tips/" | relative_url }}designing">Tips on Designing for Web Accessibility</a> - Tips for user interface and visual design</li>
 
-  <li><a href="{{ "/tips/" | relative_url }}writing.html">Tips on Writing for Web Accessibility</a> - Tips for writing and presenting content</li>
+  <li><a href="{{ "/tips/" | relative_url }}writing">Tips on Writing for Web Accessibility</a> - Tips for writing and presenting content</li>
 
-  <li><a href="{{ "/tips/" | relative_url }}developing.html">Tips on Developing for Web Accessibility</a> - Tips for markup and coding </li>
+  <li><a href="{{ "/tips/" | relative_url }}developing">Tips on Developing for Web Accessibility</a> - Tips for markup and coding </li>
 
 </ul>
 


### PR DESCRIPTION
Links are not directing correctly in `https://www.w3.org/WAI/news/2015-10-01/tips-for-getting-started-with-web-accessibility/`

<img width="984" alt="Screen Shot 2021-07-09 at 3 11 56 PM" src="https://user-images.githubusercontent.com/9125423/125017871-18422080-e0c8-11eb-8569-634f2a760b1d.png">
